### PR TITLE
リンクが壊れていたので修正

### DIFF
--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -96,7 +96,7 @@ $$
   \mathsf{B}(x, y) =
   \frac{ \Gamma(x) \, \Gamma(y) }
        { \Gamma(x+y) },
-       \quad \mbox{for $x > 0$, $y > 0$}
+       \quad \mbox{for $x > 0$,\, $y > 0$}
 $$
 
 $x$をx、$y$をyとする。
@@ -375,17 +375,8 @@ long double  expintl(long double x);
 
 $$
   \mathsf{Ei}(x) =
-  \begin{cases}
-  \displaystyle
-  - \lim_{\varepsilon\to+0}\left(
-    \int_{-x}^{-\varepsilon}   \frac{e^{-t}}
-                                    {t     } \, \mathsf{d}t
-  + \int_{+\varepsilon}^\infty \frac{e^{-t}}
-                                    {t     } \, \mathsf{d}t \right) & (x>0)\\[1ex]
-  \displaystyle
   - \int_{-x}^\infty \frac{e^{-t}}
-                          {t     } \, \mathsf{d}t & (x<0)
-  \end{cases}
+                          {t     } \, \mathsf{d}t
 \;
 $$
 

--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -96,7 +96,7 @@ $$
   \mathsf{B}(x, y) =
   \frac{ \Gamma(x) \, \Gamma(y) }
        { \Gamma(x+y) },
-       \quad \mbox{for $x > 0$,\, $y > 0$}
+       \quad \mbox{for $x > 0$, $y > 0$}
 $$
 
 $x$をx、$y$をyとする。
@@ -375,8 +375,17 @@ long double  expintl(long double x);
 
 $$
   \mathsf{Ei}(x) =
+  \begin{cases}
+  \displaystyle
+  - \lim_{\varepsilon\to+0}\left(
+    \int_{-x}^{-\varepsilon}   \frac{e^{-t}}
+                                    {t     } \, \mathsf{d}t
+  + \int_{+\varepsilon}^\infty \frac{e^{-t}}
+                                    {t     } \, \mathsf{d}t \right) & (x>0)\\[1ex]
+  \displaystyle
   - \int_{-x}^\infty \frac{e^{-t}}
-                          {t     } \, \mathsf{d}t
+                          {t     } \, \mathsf{d}t & (x<0)
+  \end{cases}
 \;
 $$
 
@@ -511,7 +520,7 @@ $$
 
 注意： n \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-[第一種円柱ベッセル関数][#sf.cmath.cyl_bessel_j]も参照。
+[第一種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
 
 
 ##　球面陪ルジャンドル関数(Spherical associated Legendre functions)


### PR DESCRIPTION
指数積分は(x>0)の場合コーシーの主値によって定義されるため,
その旨を記述した.

また, 軽微な誤りを修正した.