### PR TITLE
[WIP: do not merge] ベッセル関数の名称の編集方法に関して意見募集

### DIFF
--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -101,7 +101,7 @@ $$
 
 $x$をx、$y$をyとする。
 
-## 第一種完全楕円積分(Complete elliptic integral of the first kind)
+## 第1種完全楕円積分(Complete elliptic integral of the first kind)
 
 ~~~c++
 double      comp_ellint_1(double k);
@@ -109,7 +109,7 @@ float       comp_ellint_1f(float k);
 long double comp_ellint_1l(long double k);
 ~~~
 
-効果：実引数kに対する第一種完全楕円積分(Complete elliptic integral of the first kind)を計算する。
+効果：実引数kに対する第1種完全楕円積分(Complete elliptic integral of the first kind)を計算する。
 
 戻り値：
 
@@ -121,9 +121,9 @@ $$
 
 $k$をkとする。
 
-[第一種不完全楕円積分](#sf.cmath.ellint_1)も参照。
+[第1種不完全楕円積分](#sf.cmath.ellint_1)も参照。
 
-## 第二種完全楕円積分(Complete elliptic integral of the second kind)
+## 第2種完全楕円積分(Complete elliptic integral of the second kind)
 
 ~~~c++
 double      comp_ellint_2(double k);
@@ -131,7 +131,7 @@ float       comp_ellint_2f(float k);
 long double comp_ellint_2l(long double k);
 ~~~
 
-効果：実引数kに対する第二種完全楕円積分(Complete elliptic integral of the second kind)を計算する。
+効果：実引数kに対する第2種完全楕円積分(Complete elliptic integral of the second kind)を計算する。
 
 戻り値：
 
@@ -143,9 +143,9 @@ $$
 
 $k$をkとする。
 
-[第二種不完全楕円積分](#sf.cmath.ellint_2)も参照。
+[第2種不完全楕円積分](#sf.cmath.ellint_2)も参照。
 
-## 第三種完全楕円積分(Complete elliptic integral of the third kind)
+## 第3種完全楕円積分(Complete elliptic integral of the third kind)
 
 ~~~c++
 double      comp_ellint_3(double k, double nu);
@@ -153,7 +153,7 @@ float       comp_ellint_3f(float k, float nu);
 long double comp_ellint_3l(long double k, long double nu);
 ~~~
 
-効果：実引数k, nuに対する第三種完全楕円積分(Complete elliptic integral of the third kind)を計算する。
+効果：実引数k, nuに対する第3種完全楕円積分(Complete elliptic integral of the third kind)を計算する。
 
 戻り値：
 
@@ -164,7 +164,7 @@ $$
 
 $k$をk、$\nu$をnuとする。
 
-[第三種不完全楕円積分](#sf.cmath.ellint_3)も参照。
+[第3種不完全楕円積分](#sf.cmath.ellint_3)も参照。
 
 ## 正則変形円柱ベッセル関数(Regular modified cylindrical Bessel functions) {#sf.cmath.cyl_bessel_i}
 
@@ -191,9 +191,9 @@ $\nu$をnu、$x$をxとする。
 
 注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-[第一種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
+[第1種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
 
-## 第一種円柱ベッセル関数(Cylindrical Bessel functions of the first kind) {#sf.cmath.cyl_bessel_j}
+## 第1種円柱ベッセル関数(Cylindrical Bessel functions of the first kind) {#sf.cmath.cyl_bessel_j}
 
 ~~~c++
 double       cyl_bessel_j(double nu, double x);
@@ -201,7 +201,7 @@ float        cyl_bessel_jf(float nu, float x);
 long double  cyl_bessel_jl(long double nu, long double x);
 ~~~
 
-効果：実引数nu, kに対する第一種円柱ベッセル関数(Cylindrical Bessel functions of the first kind)を計算する。
+効果：実引数nu, kに対する第1種円柱ベッセル関数(Cylindrical Bessel functions of the first kind)を計算する。
 
 戻り値：
 
@@ -256,7 +256,7 @@ $\nu$をnu、$x$をxとする。
 
 注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-[正則変形円柱ベッセル関数](#sf.cmath.cyl_bessel_i)、[第一種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)、[円柱ノイマン関数](#sf.cmath.cyl_neumann)も参照。
+[正則変形円柱ベッセル関数](#sf.cmath.cyl_bessel_i)、[第1種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)、[円柱ノイマン関数](#sf.cmath.cyl_neumann)も参照。
 
 
 ## 円柱ノイマン関数(Cylindrical Neumann functions) {#sf.cmath.cyl_neumann}
@@ -267,7 +267,7 @@ float        cyl_neumannf(float nu, float x);
 long double  cyl_neumannl(long double nu, long double x);
 ~~~
 
-効果：実引数nu, xに対する円柱ノイマン関数(Cylindrical Neumann functions)、またの名を第二種円柱ベッセル関数(Cylindrical Bessel functions of the second kind)を計算する。
+効果：実引数nu, xに対する円柱ノイマン関数(Cylindrical Neumann functions)、またの名を第2種円柱ベッセル関数(Cylindrical Bessel functions of the second kind)を計算する。
 
 戻り値：
 
@@ -293,9 +293,9 @@ $\nu$をnu、$x$をxとする。
 
 注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-[第一種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
+[第1種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
 
-## 第一種不完全楕円積分(Incomplete elliptic integral of the first kind) {#sf.cmath.ellint_1}
+## 第1種不完全楕円積分(Incomplete elliptic integral of the first kind) {#sf.cmath.ellint_1}
 
 ~~~c++
 double       ellint_1(double k, double phi);
@@ -303,7 +303,7 @@ float        ellint_1f(float k, float phi);
 long double  ellint_1l(long double k, long double phi);
 ~~~
 
-効果：実引数k, phi(phiの単位はラジアン)に対する第一種不完全楕円積分(Incomplete elliptic integral of the first kind)を計算する。
+効果：実引数k, phi(phiの単位はラジアン)に対する第1種不完全楕円積分(Incomplete elliptic integral of the first kind)を計算する。
 
 戻り値：
 
@@ -317,7 +317,7 @@ $$
 $k$をk、$\phi$をphiとする。
 
 
-## 第二種不完全楕円積分(Incomplete elliptic integroal of the second kind) {#sf.cmath.ellint_2}
+## 第2種不完全楕円積分(Incomplete elliptic integroal of the second kind) {#sf.cmath.ellint_2}
 
 ~~~c++
 double       ellint_2(double k, double phi);
@@ -325,7 +325,7 @@ float        ellint_2f(float k, float phi);
 long double  ellint_2l(long double k, long double phi);
 ~~~
 
-効果：実引数k, phi(phiの単位はラジアン)に対する第二種不完全楕円積分(Incomplete elliptic integral of the second kind)を計算する。
+効果：実引数k, phi(phiの単位はラジアン)に対する第2種不完全楕円積分(Incomplete elliptic integral of the second kind)を計算する。
 
 戻り値：
 
@@ -339,7 +339,7 @@ $$
 $k$をk、$\phi$をphiとする。
 
 
-## 第三種不完全楕円積分(Incomplete elliptic integral of the third kind) {#sf.cmath.ellint_3}
+## 第3種不完全楕円積分(Incomplete elliptic integral of the third kind) {#sf.cmath.ellint_3}
 
 ~~~c++
 double       ellint_3(double k, double nu, double phi);
@@ -347,7 +347,7 @@ float        ellint_3f(float k, float nu, float phi);
 long double  ellint_3l(long double k, long double nu, long double phi);
 ~~~
 
-効果：実引数k, nu, phi(phiの単位はラジアン)に対する第三種不完全楕円積分(Incomplete elliptic integral of the third kind)を計算する。
+効果：実引数k, nu, phi(phiの単位はラジアン)に対する第3種不完全楕円積分(Incomplete elliptic integral of the third kind)を計算する。
 
 戻り値：
 
@@ -491,7 +491,7 @@ $$
 
 $x$をxとする。
 
-## 第一種球ベッセル関数(Spherical Bessel functions of the first kind)
+## 第1種球ベッセル関数(Spherical Bessel functions of the first kind)
 
 ~~~c++
 double       sph_bessel(unsigned n, double x);
@@ -499,7 +499,7 @@ float        sph_besself(unsigned n, float x);
 long double  sph_bessell(unsigned n, long double x);
 ~~~
 
-効果：実引数n, xに対する第一種球ベッセル関数(Spherical Bessel functions of the first kind)を計算する。
+効果：実引数n, xに対する第1種球ベッセル関数(Spherical Bessel functions of the first kind)を計算する。
 
 戻り値：
 
@@ -511,7 +511,7 @@ $$
 
 注意： n \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-[第一種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
+[第1種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
 
 
 ## 球面ルジャンドル陪関数(Spherical associated Legendre functions)
@@ -559,7 +559,7 @@ float        sph_neumannf(unsigned n, float x);
 long double  sph_neumannl(unsigned n, long double x);
 ~~~
 
-効果：実引数n, xに対する球ノイマン関数(Spherical Neumann functions)、またの名を第二種球ベッセル関数(Spherical Bessel functions of the second kind)を計算する。
+効果：実引数n, xに対する球ノイマン関数(Spherical Neumann functions)、またの名を第2種球ベッセル関数(Spherical Bessel functions of the second kind)を計算する。
 
 戻り値：
 

--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -522,7 +522,7 @@ float        sph_legendref(unsigned l, unsigned m, float theta);
 long double  sph_legendrel(unsigned l, unsigned m, long double theta);
 ~~~
 
-効果：実引数l, m, theta(thetaの単位はラジアン)に対する球面ルジャンドル陪関数(Spherical associated Legendre functions)、またの名を球面調和関数(Spherical harmonics)を計算する。
+効果：実引数l, m, theta(thetaの単位はラジアン)に対する球面ルジャンドル陪関数(Spherical associated Legendre functions)を計算する。
 
 戻り値：
 

--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -32,7 +32,7 @@ long double function_namel() ;  // l
 
 ある関数の効果が実装定義(implementation-defined)である場合、その効果はC++標準規格で定義されず、C++実装はどのように実装してもよいという意味だ。
 
-## 陪ラゲル多項式(Associated Laguerre polynomials)
+## ラゲール陪多項式(Associated Laguerre polynomials)
 
 ~~~c++
 double      assoc_laguerre(unsigned n, unsigned m, double x);
@@ -40,7 +40,7 @@ float       assoc_laguerref(unsigned n, unsigned m, float x);
 long double assoc_laguerrel(unsigned n, unsigned m, long double x);
 ~~~
 
-効果：実引数n, m, xに対する陪ラゲル多項式(Associated Laguerre polynomials)を計算する。
+効果：実引数n, m, xに対するラゲール陪多項式(Associated Laguerre polynomials)を計算する。
 
 戻り値：
 
@@ -55,7 +55,7 @@ $n$をn、$m$をm、$x$をxとする。
 
 注意：n \>= 128 もしくは m \>= 128 のときの関数呼び出しの効果は実装定義である。
 
-## 陪ルジャンドル関数(Associated Legendre functions) {#sf.cmath.assoc_legendre}
+## ルジャンドル陪関数(Associated Legendre functions) {#sf.cmath.assoc_legendre}
 
 ~~~c++
 double      assoc_legendre(unsigned l, unsigned m, double x);
@@ -63,7 +63,7 @@ float       assoc_legendref(unsigned l, unsigned m, float x);
 long double assoc_legendrel(unsigned l, unsigned m, long double x);
 ~~~
 
-効果：実引数l, m, xに対する 陪ルジャンドル関数(Associated Legendre functions)を計算する。
+効果：実引数l, m, xに対するルジャンドル陪関数(Associated Legendre functions)を計算する。
 
 戻り値：
 
@@ -405,7 +405,7 @@ $n$をn、$x$をxとする。
 
 注意：n \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-## ラゲル多項式(Laguerre polynomials)
+## ラゲール多項式(Laguerre polynomials)
 
 ~~~c++
 double       laguerre(unsigned n, double x);
@@ -413,7 +413,7 @@ float        laguerref(unsigned n, float x);
 long double  laguerrel(unsigned n, long double x);
 ~~~
 
-効果：実引数n, xに対するラゲル多項式(Laguerre polynomials)を計算する。
+効果：実引数n, xに対するラゲール多項式(Laguerre polynomials)を計算する。
 
 戻り値：
 
@@ -491,7 +491,7 @@ $$
 
 $x$をxとする。
 
-## 第一種球面ベッセル関数(Spherical Bessel functions of the first kind)
+## 第一種球ベッセル関数(Spherical Bessel functions of the first kind)
 
 ~~~c++
 double       sph_bessel(unsigned n, double x);
@@ -499,7 +499,7 @@ float        sph_besself(unsigned n, float x);
 long double  sph_bessell(unsigned n, long double x);
 ~~~
 
-効果：実引数n, xに対する第一種球面ベッセル関数(Spherical Bessel functions of the first kind)を計算する。
+効果：実引数n, xに対する第一種球ベッセル関数(Spherical Bessel functions of the first kind)を計算する。
 
 戻り値：
 
@@ -514,7 +514,7 @@ $$
 [第一種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
 
 
-## 球面陪ルジャンドル関数(Spherical associated Legendre functions)
+## 球面ルジャンドル陪関数(Spherical associated Legendre functions)
 
 ~~~c++
 double       sph_legendre(unsigned l, unsigned m, double theta);
@@ -522,7 +522,7 @@ float        sph_legendref(unsigned l, unsigned m, float theta);
 long double  sph_legendrel(unsigned l, unsigned m, long double theta);
 ~~~
 
-効果：実引数l, m, theta(thetaの単位はラジアン)に対する 球面陪ルジャンドル関数(Spherical associated Legendre functions)を計算する。
+効果：実引数l, m, theta(thetaの単位はラジアン)に対する球面ルジャンドル陪関数(Spherical associated Legendre functions)、またの名を球面調和関数(Spherical harmonics)を計算する。
 
 戻り値：
 
@@ -549,9 +549,9 @@ $l$をl、$m$をm、$\theta$をthetaとする。
 注意：l \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
 
-[陪ルジャンドル関数](#sf.cmath.assoc_legendre)も参照。
+[ルジャンドル陪関数](#sf.cmath.assoc_legendre)も参照。
 
-## 球面ノイマン関数(Spherical Neumann functions)
+## 球ノイマン関数(Spherical Neumann functions)
 
 ~~~c++
 double       sph_neumann(unsigned n, double x);
@@ -559,7 +559,7 @@ float        sph_neumannf(unsigned n, float x);
 long double  sph_neumannl(unsigned n, long double x);
 ~~~
 
-効果：実引数n, xに対する球面ノイマン関数(Spherical Neumann functions)、またの名を第二種球面ベッセル関数(Spherical Bessel functions of the second kind)を計算する。
+効果：実引数n, xに対する球ノイマン関数(Spherical Neumann functions)、またの名を第二種球ベッセル関数(Spherical Bessel functions of the second kind)を計算する。
 
 戻り値：
 


### PR DESCRIPTION
## 問題点

本文中で第一種円柱ベッセル関数・円柱ノイマン関数としているものは、数学ではそれぞれ

- 第1種ベッセル関数 (別名 第1種円柱関数)
- ノイマン関数 (別名 第2種ベッセル関数、第2種円柱関数)

と呼びます。"円柱ベッセル関数・円柱ノイマン関数 (cylindrical Bessel/Neumann function)" という名称は GSL のマニュアル由来ではないかと思われますが、数学ではそのような名称はなく違和感があります。また同様に 正則・非正則変形円柱ベッセル関数も、数学的には第1種・第2種変形ベッセル関数です。更に、球面ルジャンドル陪関数という名称も数学にはなく、~~代わりに球面調和関数と呼ばれます。~~

問題は、実は規格にある英語 Cylindrical Bessel functions of the first kind, etc. の時点で、すでに数学では使われない名称になっていることにあります。

## 編集方法の可能性

ここで二通りの編集方法が考えられます (以下)。個人的には規格を尊重して "編集方法1" が無難かと考えています。ご意見をいただければと思います。

- **編集方法1** 現状通り、英語の直訳にし、本文中の説明で「数学的には～と呼ばれている関数である」などの旨を追記する
- **編集方法2** 英語の直訳ではなく一般的な和名にする


