### PR TITLE
fix example code

### DIFF
--- a/007-cpp14-core-decltype-auto.md
+++ b/007-cpp14-core-decltype-auto.md
@@ -166,11 +166,16 @@ int main()
 autoはトップレベルのCV修飾子を消すが、decltype(auto)は保持する。
 
 ~~~cpp
+const volatile int f()
+{
+    return 0;
+}
+
 int main()
 {
     // int
     auto x1 = f() ;
-    // int &
+    // const volatile int
     decltype(auto) x2 = f() ;
 }
 ~~~


### PR DESCRIPTION
「autoはトップレベルのCV修飾子を消すが、decltype(auto)は保持する。」
のサンプルが一つ上のリファレンス参照子のものと同じになっていました