### PR TITLE
Update 034-structured-bindings.md

### DIFF
--- a/034-structured-bindings.md
+++ b/034-structured-bindings.md
@@ -193,7 +193,7 @@ int main()
 ~~~c++
 int main()
 {
-    int expr[] = { 1,2 } ;
+    constexpr int expr[] = { 1,2 } ;
 
     // エラー
     constexpr auto [a,b] = expr ;


### PR DESCRIPTION
> 構造化束縛はconstexprにはできない。

と主張するなら`=`の右側は定数に評価できるものを使うべきではないか？