### PR TITLE
045: ベッセル関数の名称 + その他の修正

### DIFF
--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -174,7 +174,7 @@ float        cyl_bessel_if(float nu, float x);
 long double  cyl_bessel_il(long double nu, long double x);
 ~~~
 
-効果：実引数nu, xに対する第1種変形ベッセル関数を計算する。
+効果：実引数nu, xに対する第1種変形ベッセル関数(Regular modified cylindrical Bessel functions, Modified Bessel functions of the first kind)を計算する。
 
 戻り値：
 
@@ -201,7 +201,7 @@ float        cyl_bessel_jf(float nu, float x);
 long double  cyl_bessel_jl(long double nu, long double x);
 ~~~
 
-効果：実引数nu, kに対する第1種ベッセル関数(Cylindrical Bessel functions of the first kind)を計算する。
+効果：実引数nu, kに対する第1種ベッセル関数(Cylindrical Bessel functions of the first kind, Bessel functions of the first kind)を計算する。
 
 戻り値：
 
@@ -224,7 +224,7 @@ float        cyl_bessel_kf(float nu, float x);
 long double  cyl_bessel_kl(long double nu, long double x);
 ~~~
 
-効果：実引数nu, xに対する第2種変形ベッセル関数(Irregular modified cylindrical Bessel functions)を計算する。
+効果：実引数nu, xに対する第2種変形ベッセル関数(Irregular modified cylindrical Bessel functions, Modified Bessel functions of the second kind)を計算する。
 
 戻り値：
 
@@ -267,7 +267,7 @@ float        cyl_neumannf(float nu, float x);
 long double  cyl_neumannl(long double nu, long double x);
 ~~~
 
-効果：実引数nu, xに対するノイマン関数(Cylindrical Neumann functions)、またの名を第2種ベッセル関数(Cylindrical Bessel functions of the second kind)を計算する。
+効果：実引数nu, xに対するノイマン関数(Cylindrical Neumann functions, Neumann functions)、またの名を第2種ベッセル関数(Cylindrical Bessel functions of the second kind, Bessel functions of the second kind)を計算する。
 
 戻り値：
 

--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -484,7 +484,7 @@ $\nu$をnu、$x$をxとする。
 
 注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-[正則変形ベッセル関数](#sf.cmath.cyl_bessel_i)、[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)、[ノイマン関数](#sf.cmath.cyl_neumann)も参照。
+[第1種変形ベッセル関数](#sf.cmath.cyl_bessel_i)、[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)、[ノイマン関数](#sf.cmath.cyl_neumann)も参照。
 
 
 ## 第1種球ベッセル関数(Spherical Bessel functions of the first kind)

--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -1,6 +1,6 @@
 # 数学の特殊関数群
 
-C++17では数学の特殊関数群(mathematical special functions)が追加された。
+C++17では数学の特殊関数群(mathematical special functions)がヘッダーファイル\<cmath\>に追加された。
 
 数学の特殊関数は、いずれも実引数をとって、規定の計算をし、結果を浮動小数点数型の戻り値として返す。
 

--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -32,6 +32,30 @@ long double function_namel() ;  // l
 
 ある関数の効果が実装定義(implementation-defined)である場合、その効果はC++標準規格で定義されず、C++実装はどのように実装してもよいという意味だ。
 
+## ラゲール多項式(Laguerre polynomials)
+
+~~~c++
+double       laguerre(unsigned n, double x);
+float        laguerref(unsigned n, float x);
+long double  laguerrel(unsigned n, long double x);
+~~~
+
+効果：実引数n, xに対するラゲール多項式(Laguerre polynomials)を計算する。
+
+戻り値：
+
+$$
+  \mathsf{L}_n(x) =
+  \frac{e^x}{n!} \frac{ \mathsf{d} ^ n}
+		    { \mathsf{d}x ^ n} \, (x^n e^{-x}),
+	   \quad \mbox{for $x \ge 0$}
+$$
+
+$n$をn、$x$をxとする。
+
+注意： n \>= 128のときの関数の呼び出しの効果は実装定義である。
+
+
 ## ラゲール陪多項式(Associated Laguerre polynomials)
 
 ~~~c++
@@ -54,6 +78,33 @@ $$
 $n$をn、$m$をm、$x$をxとする。
 
 注意：n \>= 128 もしくは m \>= 128 のときの関数呼び出しの効果は実装定義である。
+
+
+## ルジャンドル多項式(Legendre polynomials)
+
+~~~c++
+double       legendre(unsigned l, double x);
+float        legendref(unsigned l, float x);
+long double  legendrel(unsigned l, long double x);
+~~~
+
+効果：実引数l, xに対するルジャンドル多項式(Legendre polynomials)を計算する。
+
+戻り値：
+
+$$
+  \mathsf{P}_\ell(x) =
+  \frac{1}
+       {2^\ell \, \ell!}
+  \frac{ \mathsf{d} ^ \ell}
+       { \mathsf{d}x ^ \ell} \, (x^2 - 1) ^ \ell,
+	   \quad \mbox{for $|x| \le 1$}
+$$
+
+$l$をl、$x$をxとする。
+
+注意：l \>= 128 のときの関数の呼び出しの効果は実装定義である。
+
 
 ## ルジャンドル陪関数(Associated Legendre functions) {#sf.cmath.assoc_legendre}
 
@@ -80,6 +131,67 @@ $l$をl、$m$をm、$x$をxとする。
 
 注意：l \>= 128 のときの関数呼び出しの効果は実装定義である。
 
+## 球面ルジャンドル陪関数(Spherical associated Legendre functions)
+
+~~~c++
+double       sph_legendre(unsigned l, unsigned m, double theta);
+float        sph_legendref(unsigned l, unsigned m, float theta);
+long double  sph_legendrel(unsigned l, unsigned m, long double theta);
+~~~
+
+効果：実引数l, m, theta(thetaの単位はラジアン)に対する球面ルジャンドル陪関数(Spherical associated Legendre functions)を計算する。
+
+戻り値：
+
+$$
+  \mathsf{Y}_\ell^m(\theta, 0)
+$$
+
+このとき、
+
+$$
+  \mathsf{Y}_\ell^m(\theta, \phi) =
+  (-1)^m \left[ \frac{(2 \ell + 1)}
+                     {4 \pi}
+	        \frac{(\ell - m)!}
+	             {(\ell + m)!}
+         \right]^{1/2}
+	 \mathsf{P}_\ell^m
+	 ( \cos\theta ) e ^ {i m \phi},
+	   \quad \mbox{for $|m| \le \ell$}
+$$
+
+$l$をl、$m$をm、$\theta$をthetaとする。
+
+注意：l \>= 128 のときの関数の呼び出しの効果は実装定義である。
+
+[ルジャンドル陪関数](#sf.cmath.assoc_legendre)も参照。
+
+
+## エルミート多項式(Hermite polynomials)
+
+~~~c++
+double       hermite(unsigned n, double x);
+float        hermitef(unsigned n, float x);
+long double  hermitel(unsigned n, long double x);
+~~~
+
+効果：実引数n, xに対するエルミート多項式(Hermite polynomials)を計算する。
+
+戻り値：
+
+$$
+  \mathsf{H}_n(x) =
+  (-1)^n e^{x^2} \frac{ \mathsf{d} ^n}
+		      { \mathsf{d}x^n} \, e^{-x^2}
+\;
+$$
+
+$n$をn、$x$をxとする。
+
+注意：n \>= 128 のときの関数の呼び出しの効果は実装定義である。
+
+
 ## ベータ関数(Beta function)
 
 ~~~c++
@@ -100,6 +212,7 @@ $$
 $$
 
 $x$をx、$y$をyとする。
+
 
 ## 第1種完全楕円積分(Complete elliptic integral of the first kind)
 
@@ -165,135 +278,6 @@ $$
 $k$をk、$\nu$をnuとする。
 
 [第3種不完全楕円積分](#sf.cmath.ellint_3)も参照。
-
-## 第1種変形ベッセル関数(Regular modified cylindrical Bessel functions) {#sf.cmath.cyl_bessel_i}
-
-~~~c++
-double       cyl_bessel_i(double nu, double x);
-float        cyl_bessel_if(float nu, float x);
-long double  cyl_bessel_il(long double nu, long double x);
-~~~
-
-効果：実引数nu, xに対する第1種変形ベッセル関数(Regular modified cylindrical Bessel functions, Modified Bessel functions of the first kind)を計算する。
-
-戻り値：
-
-$$
-  \mathsf{I}_\nu(x) =
-  \mathrm{i}^{-\nu} \mathsf{J}_\nu(\mathrm{i}x)
-  =
-  \sum_{k=0}^\infty \frac{(x/2)^{\nu+2k}}
-			 {k! \: \Gamma(\nu+k+1)},
-	   \quad \mbox{for $x \ge 0$}
-$$
-
-$\nu$をnu、$x$をxとする。
-
-注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
-
-[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
-
-## 第1種ベッセル関数(Cylindrical Bessel functions of the first kind) {#sf.cmath.cyl_bessel_j}
-
-~~~c++
-double       cyl_bessel_j(double nu, double x);
-float        cyl_bessel_jf(float nu, float x);
-long double  cyl_bessel_jl(long double nu, long double x);
-~~~
-
-効果：実引数nu, kに対する第1種ベッセル関数(Cylindrical Bessel functions of the first kind, Bessel functions of the first kind)を計算する。
-
-戻り値：
-
-$$
-  \mathsf{J}_\nu(x) =
-  \sum_{k=0}^\infty \frac{(-1)^k (x/2)^{\nu+2k}}
-			 {k! \: \Gamma(\nu+k+1)},
-	   \quad \mbox{for $x \ge 0$}
-$$
-
-$\nu$をnu、$x$をxとする。
-
-注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
-
-## 第2種変形ベッセル関数(Irregular modified cylindrical Bessel functions)
-
-~~~c++
-double       cyl_bessel_k(double nu, double x);
-float        cyl_bessel_kf(float nu, float x);
-long double  cyl_bessel_kl(long double nu, long double x);
-~~~
-
-効果：実引数nu, xに対する第2種変形ベッセル関数(Irregular modified cylindrical Bessel functions, Modified Bessel functions of the second kind)を計算する。
-
-戻り値：
-
-$$
-  \mathsf{K}_\nu(x) =
-  (\pi/2)\mathrm{i}^{\nu+1} (            \mathsf{J}_\nu(\mathrm{i}x)
-			    + \mathrm{i} \mathsf{N}_\nu(\mathrm{i}x)
-			    )
-  =
-  \left\{
-  \begin{array}{cl}
-  \displaystyle
-  \frac{\pi}{2}
-  \frac{\mathsf{I}_{-\nu}(x) - \mathsf{I}_{\nu}(x)}
-       {\sin \nu\pi },
-  & \mbox{for $x \ge 0$ and non-integral $\nu$}
-  \\
-  \\
-  \displaystyle
-  \frac{\pi}{2}
-  \lim_{\mu \rightarrow \nu} \frac{\mathsf{I}_{-\mu}(x) - \mathsf{I}_{\mu}(x)}
-                                  {\sin \mu\pi },
-  & \mbox{for $x \ge 0$ and integral $\nu$}
-  \end{array}
-  \right.
-$$
-
-$\nu$をnu、$x$をxとする。
-
-注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
-
-[正則変形ベッセル関数](#sf.cmath.cyl_bessel_i)、[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)、[ノイマン関数](#sf.cmath.cyl_neumann)も参照。
-
-
-## ノイマン関数(Cylindrical Neumann functions) {#sf.cmath.cyl_neumann}
-
-~~~c++
-double       cyl_neumann(double nu, double x);
-float        cyl_neumannf(float nu, float x);
-long double  cyl_neumannl(long double nu, long double x);
-~~~
-
-効果：実引数nu, xに対するノイマン関数(Cylindrical Neumann functions, Neumann functions)、またの名を第2種ベッセル関数(Cylindrical Bessel functions of the second kind, Bessel functions of the second kind)を計算する。
-
-戻り値：
-
-$$
-  \mathsf{N}_\nu(x) =
-  \left\{
-  \begin{array}{cl}
-  \displaystyle
-  \frac{\mathsf{J}_\nu(x) \cos \nu\pi - \mathsf{J}_{-\nu}(x)}
-       {\sin \nu\pi },
-  & \mbox{for $x \ge 0$ and non-integral $\nu$}
-  \\
-  \\
-  \displaystyle
-  \lim_{\mu \rightarrow \nu} \frac{\mathsf{J}_\mu(x) \cos \mu\pi - \mathsf{J}_{-\mu}(x)}
-                                {\sin \mu\pi },
-  & \mbox{for $x \ge 0$ and integral $\nu$}
-  \end{array}
-  \right.
-$$
-
-$\nu$をnu、$x$をxとする。
-
-注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
-
-[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
 
 ## 第1種不完全楕円積分(Incomplete elliptic integral of the first kind) {#sf.cmath.ellint_1}
 
@@ -361,6 +345,183 @@ $$
 $\nu$をnu、$k$をk、$\phi$をphiとする。
 
 
+## 第1種ベッセル関数(Cylindrical Bessel functions of the first kind) {#sf.cmath.cyl_bessel_j}
+
+~~~c++
+double       cyl_bessel_j(double nu, double x);
+float        cyl_bessel_jf(float nu, float x);
+long double  cyl_bessel_jl(long double nu, long double x);
+~~~
+
+効果：実引数nu, kに対する第1種ベッセル関数(Cylindrical Bessel functions of the first kind, Bessel functions of the first kind)を計算する。
+
+戻り値：
+
+$$
+  \mathsf{J}_\nu(x) =
+  \sum_{k=0}^\infty \frac{(-1)^k (x/2)^{\nu+2k}}
+			 {k! \: \Gamma(\nu+k+1)},
+	   \quad \mbox{for $x \ge 0$}
+$$
+
+$\nu$をnu、$x$をxとする。
+
+注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
+
+## ノイマン関数(Cylindrical Neumann functions) {#sf.cmath.cyl_neumann}
+
+~~~c++
+double       cyl_neumann(double nu, double x);
+float        cyl_neumannf(float nu, float x);
+long double  cyl_neumannl(long double nu, long double x);
+~~~
+
+効果：実引数nu, xに対するノイマン関数(Cylindrical Neumann functions, Neumann functions)、またの名を第2種ベッセル関数(Cylindrical Bessel functions of the second kind, Bessel functions of the second kind)を計算する。
+
+戻り値：
+
+$$
+  \mathsf{N}_\nu(x) =
+  \left\{
+  \begin{array}{cl}
+  \displaystyle
+  \frac{\mathsf{J}_\nu(x) \cos \nu\pi - \mathsf{J}_{-\nu}(x)}
+       {\sin \nu\pi },
+  & \mbox{for $x \ge 0$ and non-integral $\nu$}
+  \\
+  \\
+  \displaystyle
+  \lim_{\mu \rightarrow \nu} \frac{\mathsf{J}_\mu(x) \cos \mu\pi - \mathsf{J}_{-\mu}(x)}
+                                {\sin \mu\pi },
+  & \mbox{for $x \ge 0$ and integral $\nu$}
+  \end{array}
+  \right.
+$$
+
+$\nu$をnu、$x$をxとする。
+
+注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
+
+[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
+
+
+## 第1種変形ベッセル関数(Regular modified cylindrical Bessel functions) {#sf.cmath.cyl_bessel_i}
+
+~~~c++
+double       cyl_bessel_i(double nu, double x);
+float        cyl_bessel_if(float nu, float x);
+long double  cyl_bessel_il(long double nu, long double x);
+~~~
+
+効果：実引数nu, xに対する第1種変形ベッセル関数(Regular modified cylindrical Bessel functions, Modified Bessel functions of the first kind)を計算する。
+
+戻り値：
+
+$$
+  \mathsf{I}_\nu(x) =
+  \mathrm{i}^{-\nu} \mathsf{J}_\nu(\mathrm{i}x)
+  =
+  \sum_{k=0}^\infty \frac{(x/2)^{\nu+2k}}
+			 {k! \: \Gamma(\nu+k+1)},
+	   \quad \mbox{for $x \ge 0$}
+$$
+
+$\nu$をnu、$x$をxとする。
+
+注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
+
+[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
+
+## 第2種変形ベッセル関数(Irregular modified cylindrical Bessel functions)
+
+~~~c++
+double       cyl_bessel_k(double nu, double x);
+float        cyl_bessel_kf(float nu, float x);
+long double  cyl_bessel_kl(long double nu, long double x);
+~~~
+
+効果：実引数nu, xに対する第2種変形ベッセル関数(Irregular modified cylindrical Bessel functions, Modified Bessel functions of the second kind)を計算する。
+
+戻り値：
+
+$$
+  \mathsf{K}_\nu(x) =
+  (\pi/2)\mathrm{i}^{\nu+1} (            \mathsf{J}_\nu(\mathrm{i}x)
+			    + \mathrm{i} \mathsf{N}_\nu(\mathrm{i}x)
+			    )
+  =
+  \left\{
+  \begin{array}{cl}
+  \displaystyle
+  \frac{\pi}{2}
+  \frac{\mathsf{I}_{-\nu}(x) - \mathsf{I}_{\nu}(x)}
+       {\sin \nu\pi },
+  & \mbox{for $x \ge 0$ and non-integral $\nu$}
+  \\
+  \\
+  \displaystyle
+  \frac{\pi}{2}
+  \lim_{\mu \rightarrow \nu} \frac{\mathsf{I}_{-\mu}(x) - \mathsf{I}_{\mu}(x)}
+                                  {\sin \mu\pi },
+  & \mbox{for $x \ge 0$ and integral $\nu$}
+  \end{array}
+  \right.
+$$
+
+$\nu$をnu、$x$をxとする。
+
+注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
+
+[正則変形ベッセル関数](#sf.cmath.cyl_bessel_i)、[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)、[ノイマン関数](#sf.cmath.cyl_neumann)も参照。
+
+
+## 第1種球ベッセル関数(Spherical Bessel functions of the first kind)
+
+~~~c++
+double       sph_bessel(unsigned n, double x);
+float        sph_besself(unsigned n, float x);
+long double  sph_bessell(unsigned n, long double x);
+~~~
+
+効果：実引数n, xに対する第1種球ベッセル関数(Spherical Bessel functions of the first kind)を計算する。
+
+戻り値：
+
+$$
+  \mathsf{j}_n(x) =
+  (\pi/2x)^{1\!/\!2} \mathsf{J}_{n + 1\!/\!2}(x),
+	   \quad \mbox{for $x \ge 0$}
+$$
+
+注意： n \>= 128 のときの関数の呼び出しの効果は実装定義である。
+
+[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
+
+## 球ノイマン関数(Spherical Neumann functions)
+
+~~~c++
+double       sph_neumann(unsigned n, double x);
+float        sph_neumannf(unsigned n, float x);
+long double  sph_neumannl(unsigned n, long double x);
+~~~
+
+効果：実引数n, xに対する球ノイマン関数(Spherical Neumann functions)、またの名を第2種球ベッセル関数(Spherical Bessel functions of the second kind)を計算する。
+
+戻り値：
+
+$$
+  \mathsf{n}_n(x) =
+  (\pi/2x)^{1\!/\!2} \mathsf{N}_{n + 1\!/\!2}(x),
+	   \quad \mbox{for $x \ge 0$}
+$$
+
+$n$をn、$x$をxとする。
+
+注意：n \>= 128 のときの関数の呼び出しの効果は実装定義である。
+
+[ノイマン関数](#sf.cmath.cyl_neumann)も参照。
+
+
 ## 指数積分(Exponential integral)
 
 ~~~c++
@@ -382,76 +543,6 @@ $$
 
 $x$をxとする。
 
-## エルミート多項式(Hermite polynomials)
-
-~~~c++
-double       hermite(unsigned n, double x);
-float        hermitef(unsigned n, float x);
-long double  hermitel(unsigned n, long double x);
-~~~
-
-効果：実引数n, xに対するエルミート多項式(Hermite polynomials)を計算する。
-
-戻り値：
-
-$$
-  \mathsf{H}_n(x) =
-  (-1)^n e^{x^2} \frac{ \mathsf{d} ^n}
-		      { \mathsf{d}x^n} \, e^{-x^2}
-\;
-$$
-
-$n$をn、$x$をxとする。
-
-注意：n \>= 128 のときの関数の呼び出しの効果は実装定義である。
-
-## ラゲール多項式(Laguerre polynomials)
-
-~~~c++
-double       laguerre(unsigned n, double x);
-float        laguerref(unsigned n, float x);
-long double  laguerrel(unsigned n, long double x);
-~~~
-
-効果：実引数n, xに対するラゲール多項式(Laguerre polynomials)を計算する。
-
-戻り値：
-
-$$
-  \mathsf{L}_n(x) =
-  \frac{e^x}{n!} \frac{ \mathsf{d} ^ n}
-		    { \mathsf{d}x ^ n} \, (x^n e^{-x}),
-	   \quad \mbox{for $x \ge 0$}
-$$
-
-$n$をn、$x$をxとする。
-
-注意： n \>= 128のときの関数の呼び出しの効果は実装定義である。
-
-## ルジャンドル多項式(Legendre polynomials)
-
-~~~c++
-double       legendre(unsigned l, double x);
-float        legendref(unsigned l, float x);
-long double  legendrel(unsigned l, long double x);
-~~~
-
-効果：実引数l, xに対するルジャンドル多項式(Legendre polynomials)を計算する。
-
-戻り値：
-
-$$
-  \mathsf{P}_\ell(x) =
-  \frac{1}
-       {2^\ell \, \ell!}
-  \frac{ \mathsf{d} ^ \ell}
-       { \mathsf{d}x ^ \ell} \, (x^2 - 1) ^ \ell,
-	   \quad \mbox{for $|x| \le 1$}
-$$
-
-$l$をl、$x$をxとする。
-
-注意：l \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
 ## リーマンゼータ関数(Riemann zeta function)
 
@@ -490,88 +581,3 @@ $$
 $$
 
 $x$をxとする。
-
-## 第1種球ベッセル関数(Spherical Bessel functions of the first kind)
-
-~~~c++
-double       sph_bessel(unsigned n, double x);
-float        sph_besself(unsigned n, float x);
-long double  sph_bessell(unsigned n, long double x);
-~~~
-
-効果：実引数n, xに対する第1種球ベッセル関数(Spherical Bessel functions of the first kind)を計算する。
-
-戻り値：
-
-$$
-  \mathsf{j}_n(x) =
-  (\pi/2x)^{1\!/\!2} \mathsf{J}_{n + 1\!/\!2}(x),
-	   \quad \mbox{for $x \ge 0$}
-$$
-
-注意： n \>= 128 のときの関数の呼び出しの効果は実装定義である。
-
-[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
-
-
-## 球面ルジャンドル陪関数(Spherical associated Legendre functions)
-
-~~~c++
-double       sph_legendre(unsigned l, unsigned m, double theta);
-float        sph_legendref(unsigned l, unsigned m, float theta);
-long double  sph_legendrel(unsigned l, unsigned m, long double theta);
-~~~
-
-効果：実引数l, m, theta(thetaの単位はラジアン)に対する球面ルジャンドル陪関数(Spherical associated Legendre functions)を計算する。
-
-戻り値：
-
-$$
-  \mathsf{Y}_\ell^m(\theta, 0)
-$$
-
-このとき、
-
-$$
-  \mathsf{Y}_\ell^m(\theta, \phi) =
-  (-1)^m \left[ \frac{(2 \ell + 1)}
-                     {4 \pi}
-	        \frac{(\ell - m)!}
-	             {(\ell + m)!}
-         \right]^{1/2}
-	 \mathsf{P}_\ell^m
-	 ( \cos\theta ) e ^ {i m \phi},
-	   \quad \mbox{for $|m| \le \ell$}
-$$
-
-$l$をl、$m$をm、$\theta$をthetaとする。
-
-注意：l \>= 128 のときの関数の呼び出しの効果は実装定義である。
-
-
-[ルジャンドル陪関数](#sf.cmath.assoc_legendre)も参照。
-
-## 球ノイマン関数(Spherical Neumann functions)
-
-~~~c++
-double       sph_neumann(unsigned n, double x);
-float        sph_neumannf(unsigned n, float x);
-long double  sph_neumannl(unsigned n, long double x);
-~~~
-
-効果：実引数n, xに対する球ノイマン関数(Spherical Neumann functions)、またの名を第2種球ベッセル関数(Spherical Bessel functions of the second kind)を計算する。
-
-戻り値：
-
-$$
-  \mathsf{n}_n(x) =
-  (\pi/2x)^{1\!/\!2} \mathsf{N}_{n + 1\!/\!2}(x),
-	   \quad \mbox{for $x \ge 0$}
-$$
-
-$n$をn、$x$をxとする。
-
-注意：n \>= 128 のときの関数の呼び出しの効果は実装定義である。
-
-
-[ノイマン関数](#sf.cmath.cyl_neumann)も参照。

--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -165,6 +165,18 @@ $l$をl、$m$をm、$\theta$をthetaとする。
 
 注意：l \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
+球面調和関数(Spherical harmonics) $\mathsf{Y}_\ell^m(\theta, \phi)$ は、以下のような関数を定義することによって計算できる。
+
+```c++
+#include <cmath>
+#include <complex>
+
+std::complex<double> spherical_harmonics(unsigned l, unsigned m, double theta, double phi)
+{
+    return std::sph_legendre(l, m, theta) * std::polar(1.0, m * phi) ;
+}
+```
+
 [ルジャンドル陪関数](#sf.cmath.assoc_legendre)も参照。
 
 

--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -166,7 +166,7 @@ $k$をk、$\nu$をnuとする。
 
 [第3種不完全楕円積分](#sf.cmath.ellint_3)も参照。
 
-## 正則変形円柱ベッセル関数(Regular modified cylindrical Bessel functions) {#sf.cmath.cyl_bessel_i}
+## 第1種変形ベッセル関数(Regular modified cylindrical Bessel functions) {#sf.cmath.cyl_bessel_i}
 
 ~~~c++
 double       cyl_bessel_i(double nu, double x);
@@ -174,7 +174,7 @@ float        cyl_bessel_if(float nu, float x);
 long double  cyl_bessel_il(long double nu, long double x);
 ~~~
 
-効果：実引数nu, xに対する正則変形円柱ベッセル関数を計算する。
+効果：実引数nu, xに対する第1種変形ベッセル関数を計算する。
 
 戻り値：
 
@@ -191,9 +191,9 @@ $\nu$をnu、$x$をxとする。
 
 注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-[第1種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
+[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
 
-## 第1種円柱ベッセル関数(Cylindrical Bessel functions of the first kind) {#sf.cmath.cyl_bessel_j}
+## 第1種ベッセル関数(Cylindrical Bessel functions of the first kind) {#sf.cmath.cyl_bessel_j}
 
 ~~~c++
 double       cyl_bessel_j(double nu, double x);
@@ -201,7 +201,7 @@ float        cyl_bessel_jf(float nu, float x);
 long double  cyl_bessel_jl(long double nu, long double x);
 ~~~
 
-効果：実引数nu, kに対する第1種円柱ベッセル関数(Cylindrical Bessel functions of the first kind)を計算する。
+効果：実引数nu, kに対する第1種ベッセル関数(Cylindrical Bessel functions of the first kind)を計算する。
 
 戻り値：
 
@@ -216,7 +216,7 @@ $\nu$をnu、$x$をxとする。
 
 注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-## 非正則変形円柱ベッセル関数(Irregular modified cylindrical Bessel functions)
+## 第2種変形ベッセル関数(Irregular modified cylindrical Bessel functions)
 
 ~~~c++
 double       cyl_bessel_k(double nu, double x);
@@ -224,7 +224,7 @@ float        cyl_bessel_kf(float nu, float x);
 long double  cyl_bessel_kl(long double nu, long double x);
 ~~~
 
-効果：実引数nu, xに対する非正則変形円柱ベッセル関数(Irregular modified cylindrical Bessel functions)を計算する。
+効果：実引数nu, xに対する第2種変形ベッセル関数(Irregular modified cylindrical Bessel functions)を計算する。
 
 戻り値：
 
@@ -256,10 +256,10 @@ $\nu$をnu、$x$をxとする。
 
 注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-[正則変形円柱ベッセル関数](#sf.cmath.cyl_bessel_i)、[第1種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)、[円柱ノイマン関数](#sf.cmath.cyl_neumann)も参照。
+[正則変形ベッセル関数](#sf.cmath.cyl_bessel_i)、[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)、[ノイマン関数](#sf.cmath.cyl_neumann)も参照。
 
 
-## 円柱ノイマン関数(Cylindrical Neumann functions) {#sf.cmath.cyl_neumann}
+## ノイマン関数(Cylindrical Neumann functions) {#sf.cmath.cyl_neumann}
 
 ~~~c++
 double       cyl_neumann(double nu, double x);
@@ -267,7 +267,7 @@ float        cyl_neumannf(float nu, float x);
 long double  cyl_neumannl(long double nu, long double x);
 ~~~
 
-効果：実引数nu, xに対する円柱ノイマン関数(Cylindrical Neumann functions)、またの名を第2種円柱ベッセル関数(Cylindrical Bessel functions of the second kind)を計算する。
+効果：実引数nu, xに対するノイマン関数(Cylindrical Neumann functions)、またの名を第2種ベッセル関数(Cylindrical Bessel functions of the second kind)を計算する。
 
 戻り値：
 
@@ -293,7 +293,7 @@ $\nu$をnu、$x$をxとする。
 
 注意：nu \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-[第1種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
+[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
 
 ## 第1種不完全楕円積分(Incomplete elliptic integral of the first kind) {#sf.cmath.ellint_1}
 
@@ -511,7 +511,7 @@ $$
 
 注意： n \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
-[第1種円柱ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
+[第1種ベッセル関数](#sf.cmath.cyl_bessel_j)も参照。
 
 
 ## 球面ルジャンドル陪関数(Spherical associated Legendre functions)
@@ -574,4 +574,4 @@ $n$をn、$x$をxとする。
 注意：n \>= 128 のときの関数の呼び出しの効果は実装定義である。
 
 
-[円柱ノイマン関数](#sf.cmath.cyl_neumann)も参照。
+[ノイマン関数](#sf.cmath.cyl_neumann)も参照。


### PR DESCRIPTION
さきの #37 での議論を受けましてベッセル関数に対して以下の変更を行いました。

- 894e470 **一般的な和名に修正**
- 469895d **説明文中の規格による英名に、一般的な英名を併記**: 英語文献を探しやすくするため

さらに以下の変更も含めています。

- b06114a **関数を紹介する順序を変更**: 元々は英語名での辞書順でしたが日本語になった今、順序が意味をなしていないので整理しました。とくに直交多項式系 (ラゲール・ルジャンドル・エルミート) とベッセル関数類 (ベッセル・変形ベッセル・球ベッセル) をそれぞれ固まって並ぶようにしました。
- 4988ec0 **球面ルジャンドル陪関数に、球面調和関数のコード例を追加**: 球面ルジャンドル陪関数という名前は数学にはありません。これは球面調和関数 $Y_\ell^m(\theta, \phi)$ (複素数) の振幅 (実数) を取り出したものですが、実際には球面調和関数の需要の方が大きいはずなので、そのコード例を追加しました。
- d248046 **ヘッダー cmath の言及**: ヘッダー情報が抜けていたので。
- ~~58924f8 **数式にピリオド . を追記**: 数式は文を為すので、そこで文が切れる場合には末尾にピリオドが必要です (英文でピリオドがなかったのは、文を切らずに where ... を続けることができたためです)。~~ (棄却)

それぞれコミットを分けていますので取捨選択 (rebase) 可能です。