### PR TITLE
空白を開ける記述が、表示されてしまっているのを修正

### DIFF
--- a/045-cpp17-lib-mathematical-special-functions.md
+++ b/045-cpp17-lib-mathematical-special-functions.md
@@ -220,7 +220,7 @@ $$
   \mathsf{B}(x, y) =
   \frac{ \Gamma(x) \, \Gamma(y) }
        { \Gamma(x+y) },
-       \quad \mbox{for $x > 0$,\, $y > 0$}
+       \quad \mbox{for $x > 0$, $y > 0$}
 $$
 
 $x$をx、$y$をyとする。


### PR DESCRIPTION
本来 空白を開けるように記述した部分が、\, と表示されてしまっているので、
記述を削除