### PR TITLE
Fix typo

### DIFF
--- a/041-cpp17-lib-optional.md
+++ b/041-cpp17-lib-optional.md
@@ -226,7 +226,7 @@ int main()
 
     try {
         std::optional<int> b ;
-        int y = b.get() ;
+        int y = b.value() ;
     } catch( std::bad_optional_access e )
     {
         // 値を保持していなかった


### PR DESCRIPTION
#62 に含めていたものを分離しました。