### PR TITLE
007: fix typo

### DIFF
--- a/007-cpp14-core-decltype-auto.md
+++ b/007-cpp14-core-decltype-auto.md
@@ -177,7 +177,7 @@ int main()
 
 decltype(auto)は単体で使わなければならない。
 
-~~~c+
+~~~c++
 // OK
 auto const x1 = 0 ; 
 // エラー


### PR DESCRIPTION
コードブロックの言語指定が間違っていたので直しました。