### PR TITLE
034: fix typo

### DIFF
--- a/034-cpp17-core-structured-bindings.md
+++ b/034-cpp17-core-structured-bindings.md
@@ -553,7 +553,7 @@ struct S
 
 int main()
 {
-    S e{1,3} ; ;
+    S e{1,3} ;
     auto [a,b] = e ;
 }
 ~~~


### PR DESCRIPTION
コード中の無駄なセミコロンを削除しました。
なお、`grep -r ";.*;" *` で調べたところ、他にこのような例はありませんでした。