### PR TITLE
fix some typos/errors

### DIFF
--- a/001-sd-6-feature-testing-recommendations.md
+++ b/001-sd-6-feature-testing-recommendations.md
@@ -111,7 +111,7 @@ int main()
 
 ## __has_cpp_attribute式
 
-C++実装が特定の属性トークンをサポートしているかどうかをしらべるには、__has_cpp_attribute式が使える。
+C++実装が特定の属性トークンをサポートしているかどうかを調べるには、__has_cpp_attribute式が使える。
 
 ~~~c++
 __has_cpp_attribute( 属性トークン )

--- a/019-cpp17-core-fold-expressions.md
+++ b/019-cpp17-core-fold-expressions.md
@@ -109,7 +109,7 @@ auto g( Types ... args )
 
 これはf(args)というパターンが展開される。
 
-fold-operatorにはいかのいずれかの二項演算子を使うことができる。
+fold-operatorには以下のいずれかの二項演算子を使うことができる。
 
 
 ~~~

--- a/058-cpp17-lib-misc-weak-ptr.md
+++ b/058-cpp17-lib-misc-weak-ptr.md
@@ -24,6 +24,6 @@ void f( Shared_ptr sptr )
     auto wptr1 = std::weak_ptr< typename Shared_ptr::element_type >( sptr ) ;
 
     // C++17
-    auto  wptr2 = typename Shared_ptr::weak_type( sptr ) ;
+    auto wptr2 = typename Shared_ptr::weak_type( sptr ) ;
 }
 ~~~

--- a/061-cpp17-lib-misc-traits.md
+++ b/061-cpp17-lib-misc-traits.md
@@ -82,7 +82,7 @@ int main()
 {
     using namespace std ;
 
-    // falae
+    // false
     constexpr bool b1 = negation< true_type >::value ;
     // true
     constexpr bool b2 = negation< false_type >::value ; 
@@ -115,7 +115,7 @@ is_invocableは関数呼び出しした結果の戻り値の型については�
 
 is_invocable_rは呼び出し可能性に加えて、関数呼び出しした結果の戻り値の型がRであることが確認される。
 
-is_nothrow_invocableとis_nothrow_invocableは、関数呼び出しが無例外保証されていることも確認する。
+is_nothrow_invocableとis_nothrow_invocable_rは、関数呼び出しが無例外保証されていることも確認する。
 
 ~~~cpp
 

--- a/072-cpp17-lib-misc-gcd-lcm.md
+++ b/072-cpp17-lib-misc-gcd-lcm.md
@@ -44,4 +44,4 @@ constexpr std::common_type_t<M,N> lcm(M m, N n)
 }
 ~~~
 
-lcm(m,n)は、mとnのどちらかがゼロの場合ゼロを返す。それ以外の場合、$\abs{m}$と$\abs{n}$の最小公倍数(Least Common Multiple)を返す。
+lcm(m,n)は、mとnのどちらかがゼロの場合ゼロを返す。それ以外の場合、$|m|$と$|n|$の最小公倍数(Least Common Multiple)を返す。

--- a/072-cpp17-lib-misc-gcd-lcm.md
+++ b/072-cpp17-lib-misc-gcd-lcm.md
@@ -29,7 +29,7 @@ constexpr std::common_type_t<M,N> gcd(M m, N n)
 }
 ~~~
 
-gcd(m, n)はmとnがともにゼロの場合ゼロを返す。それ以外の場合、$\abs{m}$と$\abs{n}$の最大公約数(Greatest Common Divisor)を返す。
+gcd(m, n)はmとnがともにゼロの場合ゼロを返す。それ以外の場合、$|m|$と$|n|$の最大公約数(Greatest Common Divisor)を返す。
 
 ### lcm : 最小公倍数
 

--- a/073-cpp17-lib-filesystem.md
+++ b/073-cpp17-lib-filesystem.md
@@ -671,7 +671,7 @@ int main()
 }
 ~~~
 
-メンバー関数options, depth, recursion_pending, pop, disable_recursion_pendingをでリファレンスできないイテレーターに対して呼び出した際の挙動は未定義だ。
+メンバー関数options, depth, recursion_pending, pop, disable_recursion_pendingをデリファレンスできないイテレーターに対して呼び出した際の挙動は未定義だ。
 
 ### オプション
 
@@ -1180,7 +1180,7 @@ void rename(const path& old_p, const path& new_p, error_code& ec) noexcept;
 
 old_pとnew_pが同じ存在するファイルを指す場合、何もしない。
 
-~~~
+~~~cpp
 int main()
 {
     using namespace std:filesystem ;


### PR DESCRIPTION
複数のファイルにおいて、以下の修正を行いました。

* 1箇所余分な空白を削除
* falae -> false
* 「is_nothrow_invocableとis_nothrow_invocableは」←左右が同じなので適切に書き換え
* LaTeX の絶対値記号 |x| は $\abs{x}$ ではなくそのまま $|x|$ なので書き換え
* 誤字「でリファレンス」を修正 (grep しましたが他の部分にこれと同じ誤字はありませんでした)
* 1箇所コードブロックに言語指定が無かったので追加
* 不自然に漢字変換されていなかった箇所の修正。「しらべる」「いかの」