### PR TITLE
Change the name of a template parameter in an example

### DIFF
--- a/030-cpp17-core-deduction-guide.md
+++ b/030-cpp17-core-deduction-guide.md
@@ -96,8 +96,8 @@ public :
 } ;
 
 
-template < typename T >
-Container( std::initializer_list<T> ) -> Container<T> ;
+template < typename U >
+Container( std::initializer_list<U> ) -> Container<U> ;
 
 
 int main()
@@ -106,6 +106,6 @@ int main()
 }
 ~~~
 
-C++コンパイラーはこの推定ガイドから、Container\<T\>::Container( std::initializer_list\<T\> )の場合はTをTとして推定すればよいことがわかる。
+C++コンパイラーはこの推定ガイドから、Container\<T\>::Container( std::initializer_list\<U\> )の場合はTをUとして推定すればよいことがわかる。
 
 機能テストマクロは__cpp_deduction_guides, 値は201606。


### PR DESCRIPTION
本文

> C++コンパイラーはこの推定ガイドから、Container\<T\>::Container( std::initializer_list\<T\> )の場合はTをTとして推定すればよいことがわかる。

において、二種類の`T` (`Container` のテンプレート引数 `T` vs 推定ガイドのテンプレート引数 `T`) が混在していて、理解していないと読めないので後者を `U` に改名