### PR TITLE
optional<T>とTの比較: 不正な記述を修正

### DIFF
--- a/041-cpp17-lib-optional.md
+++ b/041-cpp17-lib-optional.md
@@ -379,7 +379,7 @@ int main()
 
 ### optional\<T\>とTの比較
 
-`optional<T>`と`T`型の比較をする場合、`optional`は値を保持していなければならない。
+`optional<T>`と`T`型の比較をする場合、`T`側が値を保持している`optional`として扱われる。
 
 ### make_optional\<T\> : optional\<T\>を返す
 


### PR DESCRIPTION
修正前の記述だと、値を保持しない `optional<T>` と `T` との比較が
できないように読めますけど、実際はそんなことはないです。

なお、規格では `optional` の比較はテンプレート引数に２つの型
`T`, `U` を取って、異なる値型の間（たとえば `optional<int>` と
`optional<char>` など）での比較もサポートしていますが、 cpp17book では
その点は触れられていません。そのことも示すように比較まわりを全体的に
書きなおすことも考えられますが、それはけっこうめんどいので、この PR は
さしあたって明らかに不正な記述を修正するだけのものとしています。
