### PR TITLE
`\copyright`を`\textcopyright`へ変更

### DIFF
--- a/AsciiDWANGO/000-front.tex
+++ b/AsciiDWANGO/000-front.tex
@@ -24,7 +24,7 @@
 \begin{spacing}{1.0}
 \begin{small}
 本文中に記載されている社名および商品名は、一般に開発メーカーの登録商標です。\\
-なお、本文中では\texttrademark ・\copyright ・\textregistered 表示を明記しておりません。
+なお、本文中では\texttrademark ・\textcopyright ・\textregistered 表示を明記しておりません。
 \end{small}
 \end{spacing}
 \end{minipage}


### PR DESCRIPTION
### 概要

`\copyright`はT1エンコーディングでは対応されておらず、コンパイルする環境によってはエラーとなってしまうため、`\textcopyright`へ置き換えた。

### 見た目の差分

なぜか見た目の差分がない……🤔 

#### 変更前

![image](https://user-images.githubusercontent.com/612043/36344911-aad6694e-1464-11e8-91e5-b6d8e757833d.png)

#### 変更後

![image](https://user-images.githubusercontent.com/612043/36344893-653d111c-1464-11e8-81f7-aa65d2bb45f6.png)

