### PR TITLE
Fix diction

### DIFF
--- a/028-cpp17-core-constexpr-if.md
+++ b/028-cpp17-core-constexpr-if.md
@@ -348,7 +348,7 @@ void f()
 }
 ~~~
 
-もし、どうしても`constexpr`文の条件に合うときにだけ`static_assert`が使いたい場合もある。これは、`constexpr if`をネストしたりしていて、その内容を全部`static_assert`に書くのが冗長な場合だ。
+しかし、どうしても`constexpr`文の条件に合うときにだけ`static_assert`を使いたい場合もある。これは、`constexpr if`をネストしたりしていて、その内容を全部`static_assert`に書くのが冗長な場合だ。
 
 ~~~cpp
 template < typename T >


### PR DESCRIPTION
`もし`に対応する係り受け表現が無かったりしたので変更案です。